### PR TITLE
Fix/#9: 스크린 높이를 기준으로도 반응형 디자인을 적용할 수 있도록 유틸리티 함수 수정

### DIFF
--- a/src/utils/responsive.ts
+++ b/src/utils/responsive.ts
@@ -1,9 +1,22 @@
 import { Dimensions } from 'react-native';
 
-const baseDesignScreenSize = 393;
-const { width } = Dimensions.get('window');
+const BASE_DESIGN_SCREEN_WIDTH = 393;
+const BASE_DESIGN_SCREEN_HEIGHT = 852;
 
-export default function responsive(baseDesignElementSize: number): number {
-  const screenRatio = width / baseDesignScreenSize;
+const { width, height } = Dimensions.get('window');
+
+const calculateScreenRatio = (baseSize: number, screenSize: number): number => {
+  return baseSize / screenSize;
+};
+
+export default function responsive(
+  baseDesignElementSize: number,
+  basis?: 'width' | 'height',
+): number {
+  const screenRatio =
+    basis === 'height'
+      ? calculateScreenRatio(height, BASE_DESIGN_SCREEN_HEIGHT)
+      : calculateScreenRatio(width, BASE_DESIGN_SCREEN_WIDTH);
+
   return baseDesignElementSize * screenRatio;
 }


### PR DESCRIPTION
## 📌 관련 이슈
- closes #9  

## 🔑 주요 변경 사항
- `responsive` 함수의 매개변수로 `basis`를 추가하여, 스크린 높이를 기준으로도 사이즈를 반환할 수 있도록 수정 (디폴트 `basis`는 `width`)
- 상수 값 표기를 `UPPER_SNAKE_CASE`로 수정

## 📸 스크린 샷 (선택 사항)
- 변경 전
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9045c723-69af-4f93-838b-1d4540c63956">

- 변경 후
<img width="400" alt="image" src="https://github.com/user-attachments/assets/7a0cdf23-fe63-4c3d-beb6-415416145b99">

## 📖 참고 사항
