### PR TITLE
Config/#15: 이미지 모듈에 대한 타입 선언 추가

### DIFF
--- a/assets.d.ts
+++ b/assets.d.ts
@@ -1,3 +1,13 @@
+declare module '*.jpg' {
+  const content: any;
+  export default content;
+}
+
+declare module '*.png' {
+  const content: any;
+  export default content;
+}
+
 declare module '*.svg' {
   import React from 'react';
   import { SvgProps } from 'react-native-svg';


### PR DESCRIPTION
## 📌 관련 이슈
- closes #15  

## 🔑 주요 변경 사항
- `.jpg`, `.png` 확장자를 가진 이미지 모듈에 대한 타입 선언을 추가하여 TypeScript에서 정상적으로 인식할 수 있도록 수정
  - 해당 확장자를 가진 이미지 모듈에 대해서도 `import` 문을 사용하여 불러올 수 있음

## 📸 스크린 샷 (선택 사항)

## 📖 참고 사항
