### PR TITLE
Refactor/#29: useNavigate 커스텀 훅 생성

### DIFF
--- a/src/components/common/Header/index.tsx
+++ b/src/components/common/Header/index.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { View } from 'react-native';
 import styled from 'styled-components/native';
 import StyledText from '@components/common/StyledText';
-import responsive from '@utils/responsive.ts';
+import responsive from '@utils/responsive';
 
 export interface HeaderProps {
   title: string;

--- a/src/components/common/HeaderButton/index.tsx
+++ b/src/components/common/HeaderButton/index.tsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components/native';
 import { View, TouchableOpacity } from 'react-native';
-import responsive from '@utils/responsive.ts';
+import responsive from '@utils/responsive';
 
 export interface HeaderButtonProps {
   onPress: () => void;

--- a/src/hooks/useNavigate.ts
+++ b/src/hooks/useNavigate.ts
@@ -1,0 +1,27 @@
+import { useNavigation } from '@react-navigation/native';
+import { StackNavigationProp } from '@react-navigation/stack';
+import { StackParamList } from '@type/ScreenParamList';
+
+const useNavigate = () => {
+  const navigation = useNavigation<StackNavigationProp<StackParamList>>();
+
+  const navigateTo = (screen: keyof StackParamList) => {
+    navigation.navigate(screen);
+  };
+
+  const replaceTo = (screen: keyof StackParamList) => {
+    navigation.replace(screen);
+  };
+
+  const goBack = () => {
+    navigation.goBack();
+  };
+
+  return {
+    navigateTo,
+    replaceTo,
+    goBack,
+  };
+};
+
+export default useNavigate;

--- a/src/screens/Home/components/HomeHeader/index.tsx
+++ b/src/screens/Home/components/HomeHeader/index.tsx
@@ -1,6 +1,4 @@
 import React from 'react';
-import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import Header, { HeaderProps } from '@components/common/Header';
 import {
   HeaderButtonProps,
@@ -10,7 +8,7 @@ import {
 } from '@components/common/HeaderButton';
 import UserSettingsIcon from '@assets/icons/user_info.svg';
 import ShopIcon from '@assets/icons/shop.svg';
-import { StackParamList } from '@type/ScreenParamList.ts';
+import useNavigate from '@hooks/useNavigate';
 
 const UserSettingsButton: React.FC<HeaderButtonProps> = ({ onPress }) => {
   return (
@@ -32,18 +30,14 @@ const ShopButton: React.FC = () => {
 };
 
 const HomeHeader: React.FC<HeaderProps> = ({ title }) => {
-  const navigation = useNavigation<StackNavigationProp<StackParamList>>();
-
-  const handleUserSettingsPress = () => {
-    navigation.navigate('UserSettings');
-  };
+  const { navigateTo } = useNavigate();
 
   return (
     <Header
       title={title}
       rightContent={
         <HeaderButtonContainer>
-          <UserSettingsButton onPress={handleUserSettingsPress} />
+          <UserSettingsButton onPress={() => navigateTo('UserSettings')} />
           <ShopButton />
         </HeaderButtonContainer>
       }

--- a/src/screens/SocialLogin/index.tsx
+++ b/src/screens/SocialLogin/index.tsx
@@ -1,10 +1,7 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { ImageBackground, View, Image, Animated } from 'react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import styled from 'styled-components/native';
-import { StackParamList } from '@type/ScreenParamList';
 import responsive from '@utils/responsive';
 import StyledText from '@components/common/StyledText';
 import StyledButton from '@components/common/StyledButton';
@@ -14,6 +11,7 @@ import KakaoIcon from '@assets/icons/kakao.svg';
 import backgroundImage from '@assets/backgrounds/login.jpg';
 import appIcon from '@assets/icon-512.png';
 import useAnimatedValue from '@hooks/useAnimatedValue';
+import useNavigate from '@hooks/useNavigate';
 
 const SloganContainer = styled(View)`
   position: absolute;
@@ -109,7 +107,7 @@ const LoginButton: React.FC<LoginButtonProps> = ({ onPress }) => (
 
 const SocialLogin = () => {
   const [showWebView, setShowWebView] = useState(false);
-  const navigation = useNavigation<StackNavigationProp<StackParamList>>();
+  const { navigateTo } = useNavigate();
 
   const onTokenGenerated = async (token: string) => {
     try {
@@ -117,7 +115,7 @@ const SocialLogin = () => {
     } catch (error) {
       console.error('토큰을 저장하지 못했습니다.', error);
     }
-    navigation.navigate('Main');
+    navigateTo('Main');
   };
 
   if (showWebView) {

--- a/src/screens/SplashScreen/index.tsx
+++ b/src/screens/SplashScreen/index.tsx
@@ -1,15 +1,13 @@
 import React, { useCallback, useEffect } from 'react';
 import { View } from 'react-native';
 import styled from 'styled-components/native';
-import { useNavigation } from '@react-navigation/native';
-import { StackNavigationProp } from '@react-navigation/stack';
 import { useSetRecoilState } from 'recoil';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import apiClient from '@apis/client';
 import { userDataAtom } from '@recoil/atoms';
 import ScreenLayout from '@screens/ScreenLayout';
 import AnimatedIcon from '@screens/SplashScreen/AnimatedIcon';
-import { StackParamList } from '@type/ScreenParamList';
+import useNavigate from '@hooks/useNavigate';
 
 const LogoContainer = styled(View)`
   flex: 1;
@@ -18,7 +16,7 @@ const LogoContainer = styled(View)`
 `;
 
 const SplashScreen = () => {
-  const navigation = useNavigation<StackNavigationProp<StackParamList>>();
+  const { replaceTo } = useNavigate();
   const setUserData = useSetRecoilState(userDataAtom);
 
   const fetchUserData = useCallback(async () => {
@@ -42,18 +40,18 @@ const SplashScreen = () => {
         const token = await AsyncStorage.getItem('authToken');
         if (token) {
           await fetchUserData();
-          navigation.replace('Main');
+          replaceTo('Main');
         } else {
-          navigation.replace('Login');
+          replaceTo('Login');
         }
       } catch (error) {
         console.error('인증 토큰을 가져오는 데 실패했습니다.', error);
-        navigation.replace('Login');
+        replaceTo('Login');
       }
     }, 2800);
 
     return () => clearTimeout(timeout);
-  }, [navigation, fetchUserData]);
+  }, [replaceTo, fetchUserData]);
 
   return (
     <ScreenLayout backgroundColor="white">

--- a/src/screens/UserSettings/components/UserSettingsHeader/index.tsx
+++ b/src/screens/UserSettings/components/UserSettingsHeader/index.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import { useNavigation } from '@react-navigation/native';
 import Header, { HeaderProps } from '@components/common/Header';
 import {
   HeaderButtonProps,
@@ -8,6 +7,7 @@ import {
   HEADER_BUTTON_SIZE,
 } from '@components/common/HeaderButton';
 import BackIcon from '@assets/icons/back.svg';
+import useNavigate from '@hooks/useNavigate';
 
 const BackButton: React.FC<HeaderButtonProps> = ({ onPress }) => {
   return (
@@ -18,18 +18,14 @@ const BackButton: React.FC<HeaderButtonProps> = ({ onPress }) => {
 };
 
 const UserSettingsHeader: React.FC<HeaderProps> = ({ title }) => {
-  const navigation = useNavigation();
-
-  const handleBackPress = () => {
-    navigation.goBack();
-  };
+  const { goBack } = useNavigate();
 
   return (
     <Header
       title={title}
       leftContent={
         <HeaderButtonContainer>
-          <BackButton onPress={handleBackPress} />
+          <BackButton onPress={goBack} />
         </HeaderButtonContainer>
       }
     />

--- a/src/types/ScreenParamList.ts
+++ b/src/types/ScreenParamList.ts
@@ -1,8 +1,6 @@
-import { ParamListBase } from '@react-navigation/native';
-
-export interface StackParamList extends ParamListBase {
+export type StackParamList = {
   Splash: undefined;
   Login: undefined;
   Main: undefined;
   UserSettings: undefined;
-}
+};


### PR DESCRIPTION
## 📌 관련 이슈
- close: #29  

## 🔑 주요 변경 사항
- `StackParamList`를 `interface`에서 `type`으로 변경하여 타입 안전성 확보
  - 기존 `interface`로 정의된 `StackParamList`는  정의되지 않은 스크린 명에 대한 타입 에러를 발생시키지 않았음
  - `ParamListBase`를 상속 받지 않는 `type`으로 재정의

- 화면 간 이동 및 교체, 뒤로 가기 기능을 제공하는 `useNavigate` 커스텀 훅을 추가

-  커스텀 훅을 기존 컴포넌트에 적용하여 중복된 내비게이션 로직을 제거

## 📸 스크린 샷 (선택 사항)
- 정의되지 않은 스크린 명에 대한 타입 에러 발생 확인
<img width="718" alt="image" src="https://github.com/user-attachments/assets/e043775c-0061-46a6-ac55-54504513d7ec">

## 📖 참고 사항
