### PR TITLE
Style/#39: 토스트 메시지에 그림자 적용

### DIFF
--- a/src/styles/toastStyle/index.tsx
+++ b/src/styles/toastStyle/index.tsx
@@ -1,10 +1,18 @@
 import React from 'react';
+import styled from 'styled-components';
 import { Dimensions } from 'react-native';
 import { BaseToastProps, BaseToast } from 'react-native-toast-message';
+import { ShadowedView } from 'react-native-fast-shadow';
 import theme from '@styles/theme';
 import responsive from '@utils/responsive';
 
 const { width } = Dimensions.get('window');
+
+const ToastWrapper = styled(ShadowedView)`
+  shadow-opacity: 0.05;
+  shadow-radius: ${responsive(10, 'height')}px;
+  shadow-offset: 0px 0px;
+`;
 
 const commonStyle = {
   style: {
@@ -30,16 +38,18 @@ const commonStyle = {
 };
 
 const createToast = (props: BaseToastProps, borderColor: string) => (
-  <BaseToast
-    {...props}
-    style={{
-      ...commonStyle.style,
-      borderLeftColor: borderColor,
-    }}
-    contentContainerStyle={commonStyle.contentContainerStyle}
-    text1Style={commonStyle.text1Style}
-    text2Style={commonStyle.text2Style}
-  />
+  <ToastWrapper>
+    <BaseToast
+      {...props}
+      style={{
+        ...commonStyle.style,
+        borderLeftColor: borderColor,
+      }}
+      contentContainerStyle={commonStyle.contentContainerStyle}
+      text1Style={commonStyle.text1Style}
+      text2Style={commonStyle.text2Style}
+    />
+  </ToastWrapper>
 );
 
 const toastStyle = {


### PR DESCRIPTION
## 📌 관련 이슈
- closes #39  

## 🔑 주요 변경 사항
- 토스트 메시지에 그림자를 적용하여 시각적으로 배경과 분리
  - `react-native-toast-message`에서 기본으로 제공하는 그림자 효과는 플랫폼 별로 다르게 렌더링되므로, `react-native-fast-shadow`의 `ShadowedView`를 토스트 메시지의 래퍼로 감싸는 방식으로 구현

## 📸 스크린 샷 (선택 사항)
- 적용 전
<img src="https://github.com/user-attachments/assets/4f0f96dc-4cde-4874-8f5b-8d2c00a96424" width="400px">

- 적용 후
<img src="https://github.com/user-attachments/assets/2f165216-d30f-4aae-844c-e7f48531d037" width="400px" >

## 📖 참고 사항
