### PR TITLE
Feature/#45: 퀘스트 조회 API 연동 및 퀘스트 선택 모달 구현

### DIFF
--- a/src/screens/Home/components/QuestModal/QuestModalContent/index.tsx
+++ b/src/screens/Home/components/QuestModal/QuestModalContent/index.tsx
@@ -1,0 +1,96 @@
+import React, { useState } from 'react';
+import { View, ScrollView } from 'react-native';
+import styled from 'styled-components/native';
+import StyledButton from '@components/common/StyledButton';
+import SelectableItem from '@screens/Home/components/QuestModal/SelectableItem';
+import responsive from '@utils/responsive';
+import Quest from '@type/Quest';
+
+const ContentContainer = styled(View)`
+  width: 100%;
+`;
+
+const QuestListContainer = styled(ScrollView)`
+  aspect-ratio: 1;
+`;
+
+const SpacedView = styled(View)`
+  gap: ${responsive(5, 'height')}px;
+`;
+
+const ButtonContainer = styled(View)`
+  width: 100%;
+  align-items: center;
+  gap: ${responsive(5, 'height')}px;
+  margin-top: ${responsive(10, 'height')}px;
+`;
+
+interface QuestListProps {
+  quests: Quest[];
+  selectedQuestIds: number[];
+  onSelectQuest: (questId: number) => void;
+}
+
+const QuestList: React.FC<QuestListProps> = ({
+  quests,
+  selectedQuestIds,
+  onSelectQuest,
+}) => {
+  return (
+    <QuestListContainer>
+      <SpacedView>
+        {quests.map((quest) => (
+          <SelectableItem
+            key={quest.id}
+            title={quest.title}
+            iconUrl={`http://${quest.iconUrl}`}
+            isSelected={selectedQuestIds.includes(quest.id)}
+            onPress={() => onSelectQuest(quest.id)}
+          />
+        ))}
+      </SpacedView>
+    </QuestListContainer>
+  );
+};
+
+interface QuestModalContentProps {
+  quests: Quest[];
+  setModalVisible: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const QuestModalContent: React.FC<QuestModalContentProps> = ({
+  quests,
+  setModalVisible,
+}) => {
+  const [selectedQuestIds, setSelectedQuestIds] = useState<number[]>([]);
+
+  const handleSelectQuest = (questId: number) => {
+    setSelectedQuestIds((prev) => {
+      if (prev.includes(questId)) {
+        return prev.filter((id) => id !== questId);
+      } else {
+        return [...prev, questId];
+      }
+    });
+  };
+
+  return (
+    <ContentContainer>
+      <QuestList
+        quests={quests}
+        selectedQuestIds={selectedQuestIds}
+        onSelectQuest={handleSelectQuest}
+      />
+      <ButtonContainer>
+        <StyledButton
+          buttonTheme="secondary"
+          title="선택 항목 초기화"
+          onPress={() => setSelectedQuestIds([])}
+        />
+        <StyledButton title="확인" onPress={() => setModalVisible(false)} />
+      </ButtonContainer>
+    </ContentContainer>
+  );
+};
+
+export default QuestModalContent;

--- a/src/screens/Home/components/QuestModal/SelectableItem/index.tsx
+++ b/src/screens/Home/components/QuestModal/SelectableItem/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import styled from 'styled-components/native';
+import { SvgUri } from 'react-native-svg';
+import StyledText from '@components/common/StyledText';
+import responsive from '@utils/responsive';
+
+const ItemContainer = styled(TouchableOpacity)<{ isSelected?: boolean }>`
+  width: 100%;
+  background-color: ${(props) =>
+    props.isSelected ? props.theme.COLORS.ITEM_SELECTED : 'white'};
+  flex-direction: row;
+  align-items: center;
+  padding: ${responsive(15, 'height')}px ${responsive(20, 'height')}px;
+`;
+
+const ItemIcon = styled(SvgUri)`
+  margin-right: ${responsive(14, 'height')}px;
+`;
+
+const ItemTitle = styled(StyledText)`
+  font-size: ${responsive(13, 'height')}px;
+  letter-spacing: ${responsive(-0.8, 'height')}px;
+`;
+
+interface SelectableItemProps {
+  title: string;
+  iconUrl: string;
+  isSelected?: boolean;
+  onPress: () => void;
+}
+
+const SelectableItem: React.FC<SelectableItemProps> = ({
+  title,
+  iconUrl,
+  isSelected,
+  onPress,
+}) => {
+  return (
+    <ItemContainer isSelected={isSelected} onPress={onPress}>
+      <ItemIcon
+        uri={iconUrl}
+        width={responsive(24, 'height')}
+        height={responsive(24, 'height')}
+      />
+      <ItemTitle>{title}</ItemTitle>
+    </ItemContainer>
+  );
+};
+
+export default SelectableItem;

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -7,10 +7,13 @@ import HomeHeader from '@screens/Home/components/HomeHeader';
 import DailyProgress from '@screens/Home/components/DailyProgress';
 import apiClient from '@apis/client';
 import Quest from '@type/Quest';
+import ModalLayout from '@components/ModalLayout';
+import QuestModalContent from '@screens/Home/components/QuestModal/QuestModalContent';
 
 const Home = () => {
   const userData = useRecoilValue(userDataAtom);
   const [allQuests, setAllQuests] = useState<Quest[]>([]);
+  const [questModalVisible, setQuestModalVisible] = useState(false);
 
   const fetchAllQuests = useCallback(async () => {
     try {
@@ -39,6 +42,18 @@ const Home = () => {
     <ScreenLayout>
       <HomeHeader title={`${userData.nickname}님 안녕하세요!`} />
       <DailyProgress />
+      <ModalLayout
+        visible={questModalVisible}
+        title="데일리 퀘스트 선택"
+        description="데일리 퀘스트는 3개 이상 선택해야 해요."
+        content={
+          <QuestModalContent
+            quests={allQuests}
+            setModalVisible={setQuestModalVisible}
+          />
+        }
+        onClose={() => setQuestModalVisible(false)}
+      />
     </ScreenLayout>
   );
 };

--- a/src/screens/Home/index.tsx
+++ b/src/screens/Home/index.tsx
@@ -1,12 +1,39 @@
-import React from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { useRecoilValue } from 'recoil';
 import ScreenLayout from '@screens/ScreenLayout';
 import { userDataAtom } from '@recoil/atoms';
+import Toast from 'react-native-toast-message';
 import HomeHeader from '@screens/Home/components/HomeHeader';
 import DailyProgress from '@screens/Home/components/DailyProgress';
+import apiClient from '@apis/client';
+import Quest from '@type/Quest';
 
 const Home = () => {
   const userData = useRecoilValue(userDataAtom);
+  const [allQuests, setAllQuests] = useState<Quest[]>([]);
+
+  const fetchAllQuests = useCallback(async () => {
+    try {
+      const response = await apiClient.get('/api/quests/available');
+      const questsFromServer = response.data.quests.map((quest: Quest) => ({
+        id: quest.id,
+        iconUrl: quest.iconUrl,
+        title: quest.title,
+        maxCount: quest.maxCount,
+      }));
+      setAllQuests(questsFromServer);
+    } catch (error) {
+      Toast.show({
+        type: 'error',
+        text1: '퀘스트 데이터를 가져오는 데 실패했습니다.',
+        text2: String(error),
+      });
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAllQuests();
+  }, [fetchAllQuests]);
 
   return (
     <ScreenLayout>

--- a/src/styles/theme/index.ts
+++ b/src/styles/theme/index.ts
@@ -10,6 +10,7 @@ const theme = {
     TOAST_SUCCESS: '#A1F396',
     TOAST_ERROR: '#FF7171',
     TOAST_INFO: '#60AAFF',
+    ITEM_SELECTED: '#E7F5FE',
   },
   FONT_WEIGHTS: {
     THIN: 'SpoqaHanSansNeo-Thin',

--- a/src/types/Quest.ts
+++ b/src/types/Quest.ts
@@ -3,7 +3,6 @@ interface Quest {
   title: string;
   iconUrl: string;
   maxCount: number;
-  isDone: boolean;
 }
 
 export default Quest;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #45 

## 🔑 주요 변경 사항
- 서버 응답에 맞추어 `Quest` 타입의 객체 속성 수정
- 퀘스트 목록 조회 API 연동
- 퀘스트 선택 모달 구현

## 📸 스크린 샷 (선택 사항)
- 구현된 모달
<img src="https://github.com/user-attachments/assets/9be07e5f-bf59-475a-9cec-2413269d4461" width="400px" >

## 📖 참고 사항
추후 퀘스트 등록 API를 해당 모달과 연동해야 함
