### PR TITLE
Feature/#55: 던 리스트 조회 및 추가 API 연동

### DIFF
--- a/src/screens/Diary/components/DoneListHeader/index.tsx
+++ b/src/screens/Diary/components/DoneListHeader/index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { View } from 'react-native';
+import styled from 'styled-components/native';
+import MenuHeader from '@components/common/MenuHeader';
+import responsive from '@utils/responsive';
+
+const HeaderContainer = styled(View)`
+  gap: ${responsive(8, 'height')}px;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+`;
+
+const DoneListHeader = () => {
+  return (
+    <HeaderContainer>
+      <MenuHeader title="던 리스트" />
+    </HeaderContainer>
+  );
+};
+
+export default DoneListHeader;

--- a/src/screens/Diary/components/DoneListItem/index.tsx
+++ b/src/screens/Diary/components/DoneListItem/index.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import styled from 'styled-components/native';
+import ItemLayout from '@components/ItemLayout';
+import StyledText from '@components/common/StyledText';
+import responsive from '@utils/responsive';
+
+const DoneListContainer = styled(ItemLayout)`
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  height: ${responsive(60, 'height')}px;
+  border-radius: ${responsive(8, 'height')}px;
+  padding: 0 ${responsive(20, 'height')}px;
+`;
+
+const AddTaskContainer = styled(DoneListContainer)`
+  background-color: transparent;
+  border: 1px dashed gray;
+`;
+
+const ButtonWrapper = styled(TouchableOpacity)`
+  flex: 1;
+`;
+
+const DoneListTitle = styled(StyledText)`
+  font-size: ${responsive(14, 'height')}px;
+  letter-spacing: ${responsive(-0.5)}px;
+`;
+
+export const AddTaskButton = ({ onPress }: { onPress: () => void }) => {
+  return (
+    <AddTaskContainer>
+      <ButtonWrapper onPress={onPress}>
+        <DoneListTitle>➕ 항목 추가</DoneListTitle>
+      </ButtonWrapper>
+    </AddTaskContainer>
+  );
+};
+
+const DoneListItem = ({ title }: { title: string }) => {
+  return (
+    <DoneListContainer>
+      <ButtonWrapper>
+        <DoneListTitle>{title}</DoneListTitle>
+      </ButtonWrapper>
+    </DoneListContainer>
+  );
+};
+
+export default DoneListItem;

--- a/src/screens/Diary/index.tsx
+++ b/src/screens/Diary/index.tsx
@@ -1,20 +1,92 @@
-import React, { useState } from 'react';
+import React, { useState, useCallback, useEffect } from 'react';
 import { ScrollView } from 'react-native';
+import Toast from 'react-native-toast-message';
 import ScreenLayout from '@screens/ScreenLayout';
 import DiaryHeader from '@screens/Diary/components/DiaryHeader';
 import getFormatedDate from '@utils/getFormatedDate';
 import DailyInspiration from '@screens/Diary/components/DailyInspiration';
+import DoneListHeader from '@screens/Diary/components/DoneListHeader';
+import DoneListItem, {
+  AddTaskButton,
+} from '@screens/Diary/components/DoneListItem';
+import apiClient from '@apis/client';
+import DoneTask from '@type/DoneTask';
+import SpacedView from '@components/common/SpacedView';
+import responsive from '@utils/responsive';
 
 const Diary = () => {
   const [date, setDate] = useState(new Date());
+  // eslint-disable-next-line
   const [question, setQuestion] = useState('');
+  // eslint-disable-next-line
   const [saying, setSaying] = useState('');
+  const [doneList, setDoneList] = useState<DoneTask[]>([]);
+
+  const getLocalDateString = () => {
+    const offset = date.getTimezoneOffset() * 60000;
+    const dateOffset = new Date(date.getTime() - offset);
+    return dateOffset.toISOString().split('T')[0];
+  };
+
+  const localDate = getLocalDateString();
+
+  const fetchTasks = useCallback(async () => {
+    try {
+      const response = await apiClient.get(`/api/done-list/${localDate}`);
+      const tasksFromServer = response.data.donelist.map((item: any) => ({
+        id: item.itemId,
+        title: item.title,
+        content: item.content,
+      }));
+      setDoneList(tasksFromServer);
+    } catch (error) {
+      Toast.show({
+        type: 'error',
+        text1: '던 리스트를 불러오는 데 실패했습니다.',
+        text2: String(error),
+      });
+    }
+  }, [localDate]);
+
+  const addTask = async () => {
+    const formData = new FormData();
+    const newTask = {
+      doneDate: localDate,
+      title: '새로운 작업',
+      content: '',
+    };
+    formData.append('data', JSON.stringify(newTask));
+
+    try {
+      await apiClient.post('/api/done-list', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      await fetchTasks();
+    } catch (error) {
+      Toast.show({
+        type: 'error',
+        text1: '던 리스트 항목 추가에 실패했습니다.',
+        text2: String(error),
+      });
+    }
+  };
+
+  useEffect(() => {
+    fetchTasks();
+  }, [date, fetchTasks]);
 
   return (
     <ScreenLayout>
       <DiaryHeader title={getFormatedDate(date)} setDate={setDate} />
       <ScrollView showsVerticalScrollIndicator={false}>
         <DailyInspiration question={question} saying={saying} />
+        <DoneListHeader />
+        <SpacedView gap={responsive(8, 'height')}>
+          {doneList.map((item) => (
+            <DoneListItem key={item.id} title={item.title} />
+          ))}
+          <AddTaskButton onPress={addTask} />
+        </SpacedView>
       </ScrollView>
     </ScreenLayout>
   );

--- a/src/types/DoneTask.ts
+++ b/src/types/DoneTask.ts
@@ -1,0 +1,7 @@
+interface DoneTask {
+  id: number;
+  title: string;
+  content: string;
+}
+
+export default DoneTask;


### PR DESCRIPTION
## 📌 관련 이슈
- closes #55 

## 🔑 주요 변경 사항
- 던 리스트 조회 및 추가 API 연동
  - `fetchTasks` 함수로 서버에서 지정 일자의 던 리스트를 가져오고, `addTask` 함수로 해당 일자의 새로운 작업을 추가할 수 있음
    - 던 리스트를 조회하거나, 항목을 추가하기 위해 `yyyy-MM-dd` 형식의 문자열을 사용해야 함

    - `DateTimePicker`에서 반환하는 `date`는 local date가 아니므로, `yyyy-MM-dd` 형식의 local date로 변환하는 `getLocalDateString` 함수 추가

## 📸 스크린 샷 (선택 사항)
- 구현된 컴포넌트
<img src="https://github.com/user-attachments/assets/6151ce23-a54b-491b-82f0-7f6a01d8b0b7" width="400px" >

## 📖 참고 사항
