### PR TITLE
Feature/#57: 던 리스트 항목 상세 조회 및 수정, 삭제 API 연동

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -10,7 +10,8 @@
       android:allowBackup="false"
       android:theme="@style/AppTheme"
       android:supportsRtl="true"
-      android:usesCleartextTraffic="true">
+      android:usesCleartextTraffic="true"
+      android:requestLegacyExternalStorage="true">
       <activity
         android:name=".MainActivity"
         android:label="@string/app_name"

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -1243,6 +1243,27 @@ PODS:
     - react-native-config/App (= 1.5.3)
   - react-native-config/App (1.5.3):
     - React-Core
+  - react-native-image-picker (7.1.2):
+    - DoubleConversion
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-ImageManager
+    - React-NativeModulesApple
+    - React-RCTFabric
+    - React-rendererdebug
+    - React-utils
+    - ReactCodegen
+    - ReactCommon/turbomodule/bridging
+    - ReactCommon/turbomodule/core
+    - Yoga
   - react-native-netinfo (11.4.1):
     - React-Core
   - react-native-safe-area-context (4.11.0):
@@ -1687,6 +1708,7 @@ DEPENDENCIES:
   - React-Mapbuffer (from `../node_modules/react-native/ReactCommon`)
   - React-microtasksnativemodule (from `../node_modules/react-native/ReactCommon/react/nativemodule/microtasks`)
   - react-native-config (from `../node_modules/react-native-config`)
+  - react-native-image-picker (from `../node_modules/react-native-image-picker`)
   - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
   - react-native-webview (from `../node_modules/react-native-webview`)
@@ -1805,6 +1827,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native/ReactCommon/react/nativemodule/microtasks"
   react-native-config:
     :path: "../node_modules/react-native-config"
+  react-native-image-picker:
+    :path: "../node_modules/react-native-image-picker"
   react-native-netinfo:
     :path: "../node_modules/@react-native-community/netinfo"
   react-native-safe-area-context:
@@ -1918,6 +1942,7 @@ SPEC CHECKSUMS:
   React-Mapbuffer: b982d5bba94a8bc073bda48f0d27c9b28417fae3
   React-microtasksnativemodule: 2b73e68f0462f3175f98782db08896f8501afd20
   react-native-config: 8f7283449bbb048902f4e764affbbf24504454af
+  react-native-image-picker: 2fbbafdae7a7c6db9d25df2f2b1db4442d2ca2ad
   react-native-netinfo: f0a9899081c185db1de5bb2fdc1c88c202a059ac
   react-native-safe-area-context: 851c62c48dce80ccaa5637b6aa5991a1bc36eca9
   react-native-webview: 926d2665cf3196e39c4449a72d136d0a53b9df8a

--- a/ios/bloom/Info.plist
+++ b/ios/bloom/Info.plist
@@ -31,6 +31,12 @@
     </dict>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string></string>
+    <key>NSCameraUsageDescription</key>
+	<string></string>
+    <key>NSPhotoLibraryAddUsageDescription</key>
+	<string></string>
+    <key>NSPhotoLibraryUsageDescription</key>
+	<string></string>
 	<key>UIAppFonts</key>
 	<array>
 		<string>Freesentation-7Bold.ttf</string>

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-native-dotenv": "^3.4.11",
     "react-native-fast-shadow": "^0.1.1",
     "react-native-gesture-handler": "^2.20.0",
+    "react-native-image-picker": "^7.1.2",
     "react-native-linear-gradient": "^2.8.3",
     "react-native-modal-datetime-picker": "^18.0.0",
     "react-native-reanimated": "^3.15.5",

--- a/src/components/ModalLayout/index.tsx
+++ b/src/components/ModalLayout/index.tsx
@@ -1,5 +1,11 @@
 import React from 'react';
-import { Modal, View, TouchableWithoutFeedback } from 'react-native';
+import {
+  Modal,
+  View,
+  TouchableWithoutFeedback,
+  KeyboardAvoidingView,
+  Platform,
+} from 'react-native';
 import styled from 'styled-components/native';
 import Toast from 'react-native-toast-message';
 import StyledText from '@components/common/StyledText';
@@ -26,6 +32,7 @@ const ModalContainer = styled(View)`
 const ModalTitle = styled(StyledText)`
   font-family: ${(props) => props.theme.FONT_WEIGHTS.MEDIUM};
   font-size: ${responsive(16, 'height')}px;
+  margin-bottom: ${responsive(15, 'height')}px;
 `;
 
 const ModalDescription = styled(StyledText)`
@@ -33,19 +40,19 @@ const ModalDescription = styled(StyledText)`
   font-size: ${responsive(13, 'height')}px;
   letter-spacing: ${responsive(-0.5, 'height')}px;
   color: gray;
-  margin-top: ${responsive(5, 'height')}px;
+  margin-top: ${responsive(-10, 'height')}px;
+  margin-bottom: ${responsive(15, 'height')}px;
 `;
 
 const ModalContent = styled(View)`
   width: 88%;
   justify-content: center;
   align-items: center;
-  margin-top: ${responsive(15, 'height')}px;
 `;
 
 interface ModalProps {
   visible: boolean;
-  title: string;
+  title?: string;
   description?: string;
   content: React.ReactNode;
   onClose: () => void;
@@ -65,19 +72,24 @@ const ModalLayout: React.FC<ModalProps> = ({
       animationType="slide"
       onRequestClose={onClose}
     >
-      <TouchableWithoutFeedback onPress={onClose}>
-        <Overlay>
-          <TouchableWithoutFeedback>
-            <ModalContainer>
-              <ModalTitle>{title}</ModalTitle>
-              {description && (
-                <ModalDescription>{description}</ModalDescription>
-              )}
-              <ModalContent>{content}</ModalContent>
-            </ModalContainer>
-          </TouchableWithoutFeedback>
-        </Overlay>
-      </TouchableWithoutFeedback>
+      <KeyboardAvoidingView
+        style={{ flex: 1 }}
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+      >
+        <TouchableWithoutFeedback onPress={onClose}>
+          <Overlay>
+            <TouchableWithoutFeedback>
+              <ModalContainer>
+                {title && <ModalTitle>{title}</ModalTitle>}
+                {description && (
+                  <ModalDescription>{description}</ModalDescription>
+                )}
+                <ModalContent>{content}</ModalContent>
+              </ModalContainer>
+            </TouchableWithoutFeedback>
+          </Overlay>
+        </TouchableWithoutFeedback>
+      </KeyboardAvoidingView>
       <Toast
         config={toastStyle}
         position="bottom"

--- a/src/components/common/StyledButton/index.tsx
+++ b/src/components/common/StyledButton/index.tsx
@@ -48,6 +48,7 @@ interface ButtonProps {
   icon?: React.ReactNode;
   buttonStyle?: StyleProp<ViewStyle>;
   titleStyle?: StyleProp<TextStyle>;
+  disabled?: boolean;
   onPress: (...args: any[]) => any;
 }
 
@@ -57,10 +58,16 @@ const StyledButton: React.FC<ButtonProps> = ({
   icon,
   buttonStyle,
   titleStyle,
+  disabled,
   onPress,
 }) => {
   return (
-    <Button onPress={onPress} buttonTheme={buttonTheme} style={buttonStyle}>
+    <Button
+      buttonTheme={buttonTheme}
+      style={buttonStyle}
+      disabled={disabled}
+      onPress={onPress}
+    >
       {icon && <IconWrapper>{icon}</IconWrapper>}
       <ButtonTitle buttonTheme={buttonTheme} style={titleStyle}>
         {title}

--- a/src/screens/Diary/components/DiaryHeader/index.tsx
+++ b/src/screens/Diary/components/DiaryHeader/index.tsx
@@ -18,10 +18,11 @@ const CalendarButton: React.FC<HeaderButtonProps> = ({ onPress }) => {
 };
 
 interface DiaryHeaderProps extends HeaderProps {
+  date: Date;
   setDate: React.Dispatch<React.SetStateAction<Date>>;
 }
 
-const DiaryHeader: React.FC<DiaryHeaderProps> = ({ title, setDate }) => {
+const DiaryHeader: React.FC<DiaryHeaderProps> = ({ title, date, setDate }) => {
   const [datePickerVisible, setDatePickerVisible] = useState(false);
 
   const handleDateConfirm = (selectedDate: Date) => {
@@ -37,7 +38,9 @@ const DiaryHeader: React.FC<DiaryHeaderProps> = ({ title, setDate }) => {
           <CalendarButton onPress={() => setDatePickerVisible(true)} />
           <DateTimePickerModal
             isVisible={datePickerVisible}
-            mode="date"
+            display="inline"
+            locale="ko"
+            date={date}
             maximumDate={new Date()}
             onConfirm={handleDateConfirm}
             onCancel={() => setDatePickerVisible(false)}

--- a/src/screens/Diary/components/DoneListItem/index.tsx
+++ b/src/screens/Diary/components/DoneListItem/index.tsx
@@ -1,17 +1,21 @@
-import React from 'react';
-import { TouchableOpacity } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { TouchableOpacity, Animated } from 'react-native';
 import styled from 'styled-components/native';
+import { SwipeRow } from 'react-native-swipe-list-view';
 import ItemLayout from '@components/ItemLayout';
 import StyledText from '@components/common/StyledText';
 import responsive from '@utils/responsive';
+import useAnimatedValue from '@hooks/useAnimatedValue';
+import DeleteIcon from '@assets/icons/delete.svg';
 
 const DoneListContainer = styled(ItemLayout)`
   flex-direction: row;
   align-items: center;
   justify-content: flex-start;
   height: ${responsive(60, 'height')}px;
-  border-radius: ${responsive(8, 'height')}px;
   padding: 0 ${responsive(20, 'height')}px;
+  border-radius: ${responsive(8, 'height')}px;
+  overflow: hidden;
 `;
 
 const AddTaskContainer = styled(DoneListContainer)`
@@ -25,8 +29,59 @@ const ButtonWrapper = styled(TouchableOpacity)`
 
 const DoneListTitle = styled(StyledText)`
   font-size: ${responsive(14, 'height')}px;
-  letter-spacing: ${responsive(-0.5)}px;
+  letter-spacing: ${responsive(-0.5, 'height')}px;
 `;
+
+const DeleteTaskButton = styled(TouchableOpacity)`
+  height: 100%;
+  background-color: ${(props) => props.theme.COLORS.BUTTON_RED};
+  align-items: center;
+  justify-content: center;
+`;
+
+const HiddenItemContainer = styled(DoneListContainer)`
+  padding: 0;
+`;
+
+interface HiddenItemsProps {
+  taskId: number;
+  onDeleteTask: (taskId: number) => void;
+  swipeValue: Animated.Value;
+}
+
+const HiddenItems: React.FC<HiddenItemsProps> = ({
+  taskId,
+  onDeleteTask,
+  swipeValue,
+}) => {
+  const { animatedValue: buttonWidth, animateToValue } = useAnimatedValue(0);
+
+  useEffect(() => {
+    const targetWidth = responsive(55, 'height');
+    const listenerId = swipeValue.addListener(({ value }) => {
+      const width = Math.min(value, targetWidth);
+      animateToValue(width, 0, 0, false).start();
+    });
+
+    return () => {
+      swipeValue.removeListener(listenerId);
+    };
+  }, [swipeValue, animateToValue]);
+
+  return (
+    <HiddenItemContainer>
+      <Animated.View style={{ width: buttonWidth }}>
+        <DeleteTaskButton onPress={() => onDeleteTask(taskId)}>
+          <DeleteIcon
+            style={{ position: 'absolute', left: responsive(20, 'height') }}
+            width={responsive(15, 'height')}
+            height={responsive(15, 'height')}
+          />
+        </DeleteTaskButton>
+      </Animated.View>
+    </HiddenItemContainer>
+  );
+};
 
 export const AddTaskButton = ({ onPress }: { onPress: () => void }) => {
   return (
@@ -38,13 +93,47 @@ export const AddTaskButton = ({ onPress }: { onPress: () => void }) => {
   );
 };
 
-const DoneListItem = ({ title }: { title: string }) => {
+interface DoneListItemProps {
+  id: number;
+  title: string;
+  handleOpenModal: () => void;
+  handleDeleteTask: (taskId: number) => void;
+  setIsSwiping: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const DoneListItem: React.FC<DoneListItemProps> = ({
+  id,
+  title,
+  handleOpenModal,
+  handleDeleteTask,
+  setIsSwiping,
+}) => {
+  const swipeRowRef = useRef<SwipeRow<unknown> | null>(null);
+  const { animatedValue: swipeValue } = useAnimatedValue(0);
+
   return (
-    <DoneListContainer>
-      <ButtonWrapper>
-        <DoneListTitle>{title}</DoneListTitle>
-      </ButtonWrapper>
-    </DoneListContainer>
+    // @ts-expect-error
+    <SwipeRow
+      ref={swipeRowRef}
+      leftOpenValue={responsive(55, 'height')}
+      disableLeftSwipe={true}
+      onSwipeValueChange={(value) => {
+        swipeValue.setValue(value.value);
+      }}
+      swipeGestureBegan={() => setIsSwiping(true)}
+      swipeGestureEnded={() => setIsSwiping(false)}
+    >
+      <HiddenItems
+        taskId={id}
+        onDeleteTask={(taskId) => handleDeleteTask(taskId)}
+        swipeValue={swipeValue}
+      />
+      <DoneListContainer>
+        <ButtonWrapper onPress={handleOpenModal}>
+          <DoneListTitle numberOfLines={1}>{title}</DoneListTitle>
+        </ButtonWrapper>
+      </DoneListContainer>
+    </SwipeRow>
   );
 };
 

--- a/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
+++ b/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
@@ -88,7 +88,7 @@ interface TaskUpdate {
   deletedPhotoIds?: number[];
 }
 
-interface TaskModalContentHandles {
+export interface TaskModalContentHandles {
   saveTask: () => Promise<void>;
 }
 

--- a/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
+++ b/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
@@ -1,0 +1,128 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import {
+  View,
+  TextInput,
+  ScrollView,
+  TouchableOpacity,
+  Image,
+} from 'react-native';
+import styled from 'styled-components/native';
+import Toast from 'react-native-toast-message';
+import StyledButton from '@components/common/StyledButton';
+import responsive from '@utils/responsive';
+import SpacedView from '@components/common/SpacedView';
+import apiClient from '@apis/client';
+
+const ContentContainer = styled(View)`
+  width: 100%;
+`;
+
+const TaskTitle = styled(TextInput)`
+  font-size: ${responsive(14, 'height')}px;
+  padding: 0 ${responsive(15)}px;
+  margin-top: ${responsive(5, 'height')}px;
+`;
+
+const PhotoView = styled(View)`
+  flex-direction: row;
+  padding: 0 ${responsive(10)}px;
+`;
+
+const TaskPhoto = styled(Image)`
+  width: ${responsive(160)}px;
+  height: ${responsive(120)}px;
+  gap: ${responsive(8)}px;
+`;
+
+const TaskContent = styled(TextInput)`
+  height: ${responsive(120, 'height')}px;
+  font-family: ${(props) => props.theme.FONT_WEIGHTS.LIGHT};
+  font-size: ${responsive(14, 'height')}px;
+  text-align: justify;
+  text-align-vertical: top;
+  letter-spacing: ${responsive(-0.5, 'height')}px;
+  line-height: ${responsive(24, 'height')}px;
+  padding: 0 ${responsive(15)}px;
+`;
+
+const ButtonContainer = styled(View)`
+  width: 100%;
+  align-items: center;
+  gap: ${responsive(5, 'height')}px;
+  margin-top: ${responsive(10, 'height')}px;
+`;
+
+const TaskModalContent = ({ id }: { id: number }) => {
+  const [taskTitle, setTaskTitle] = useState<string>('');
+  const [taskContent, setTaskContent] = useState<string>('');
+  const [taskPhotos, setTaskPhotos] = useState([]);
+
+  const fetchTaskDetail = useCallback(async () => {
+    try {
+      const response = await apiClient.get(`/api/done-list/detail/${id}`);
+      const { doneItem } = response.data;
+      const { photoUrls } = response.data;
+
+      setTaskTitle(doneItem.title);
+      setTaskContent(doneItem.content);
+      setTaskPhotos(photoUrls);
+    } catch (error) {
+      Toast.show({
+        type: 'error',
+        text1: '던 리스트를 불러오는 데 실패했습니다.',
+        text2: String(error),
+      });
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchTaskDetail();
+  }, [fetchTaskDetail]);
+
+  return (
+    <ContentContainer>
+      <SpacedView gap={responsive(20, 'height')}>
+        <TaskTitle
+          value={taskTitle}
+          onChangeText={setTaskTitle}
+          placeholder="제목"
+          maxLength={50}
+        />
+        {taskPhotos.length > 0 && (
+          <ScrollView
+            horizontal
+            contentContainerStyle={{
+              flexGrow: 1,
+              justifyContent: 'center',
+            }}
+          >
+            <PhotoView>
+              {taskPhotos.map((photo: { id: number; url: string }) => (
+                <TouchableOpacity key={photo.id}>
+                  <TaskPhoto source={{ uri: photo.url }} />
+                </TouchableOpacity>
+              ))}
+            </PhotoView>
+          </ScrollView>
+        )}
+        <TaskContent
+          value={taskContent}
+          onChangeText={setTaskContent}
+          placeholder="어떤 일을 하셨나요? (최대 500자)"
+          maxLength={500}
+          multiline={true}
+        />
+      </SpacedView>
+      <ButtonContainer>
+        <StyledButton
+          buttonTheme="secondary"
+          title={`사진 추가 (${taskPhotos.length}/3)`}
+          onPress={() => console.log('사진 추가')}
+        />
+        <StyledButton title="저장" onPress={() => console.log('저장')} />
+      </ButtonContainer>
+    </ContentContainer>
+  );
+};
+
+export default TaskModalContent;

--- a/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
+++ b/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
@@ -1,12 +1,25 @@
-import React, { useState, useCallback, useEffect } from 'react';
+import React, {
+  useState,
+  useCallback,
+  useEffect,
+  forwardRef,
+  useImperativeHandle,
+} from 'react';
 import {
   View,
   TextInput,
   ScrollView,
   TouchableOpacity,
   Image,
+  Platform,
+  Alert,
 } from 'react-native';
 import styled from 'styled-components/native';
+import {
+  launchImageLibrary,
+  ImageLibraryOptions,
+  ImagePickerResponse,
+} from 'react-native-image-picker';
 import Toast from 'react-native-toast-message';
 import StyledButton from '@components/common/StyledButton';
 import responsive from '@utils/responsive';
@@ -26,6 +39,7 @@ const TaskTitle = styled(TextInput)`
 const PhotoView = styled(View)`
   flex-direction: row;
   padding: 0 ${responsive(10)}px;
+  gap: ${responsive(10)}px;
 `;
 
 const TaskPhoto = styled(Image)`
@@ -52,20 +66,59 @@ const ButtonContainer = styled(View)`
   margin-top: ${responsive(10, 'height')}px;
 `;
 
-const TaskModalContent = ({ id }: { id: number }) => {
+const IMAGE_QUALITY = 1;
+const MAX_PHOTO_COUNT = 3;
+
+interface Photo {
+  id: number;
+  url: string;
+  name?: string;
+  type?: string;
+}
+
+interface Task {
+  title: string;
+  content: string;
+  photos: Photo[];
+}
+
+interface TaskUpdate {
+  title?: string;
+  content?: string;
+  deletedPhotoIds?: number[];
+}
+
+interface TaskModalContentHandles {
+  saveTask: () => Promise<void>;
+}
+
+interface TaskModalContentProps {
+  id: number;
+  fetchTasks: () => void;
+  setIsTaskModified: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+const TaskModalContent = forwardRef<
+  TaskModalContentHandles,
+  TaskModalContentProps
+>(({ id, fetchTasks, setIsTaskModified }, ref) => {
   const [taskTitle, setTaskTitle] = useState<string>('');
   const [taskContent, setTaskContent] = useState<string>('');
-  const [taskPhotos, setTaskPhotos] = useState([]);
+  const [taskPhotos, setTaskPhotos] = useState<Photo[]>([]);
+  const [initialTaskState, setInitialTaskState] = useState<Task | null>(null);
 
   const fetchTaskDetail = useCallback(async () => {
     try {
-      const response = await apiClient.get(`/api/done-list/detail/${id}`);
-      const { doneItem } = response.data;
-      const { photoUrls } = response.data;
-
+      const { data } = await apiClient.get(`/api/done-list/detail/${id}`);
+      const { doneItem, photoUrls } = data;
       setTaskTitle(doneItem.title);
       setTaskContent(doneItem.content);
       setTaskPhotos(photoUrls);
+      setInitialTaskState({
+        title: doneItem.title,
+        content: doneItem.content,
+        photos: photoUrls,
+      });
     } catch (error) {
       Toast.show({
         type: 'error',
@@ -75,9 +128,122 @@ const TaskModalContent = ({ id }: { id: number }) => {
     }
   }, [id]);
 
+  const handlePickImage = () => {
+    const options: ImageLibraryOptions = {
+      mediaType: 'photo',
+      quality: IMAGE_QUALITY,
+      selectionLimit: MAX_PHOTO_COUNT - taskPhotos.length,
+    };
+
+    launchImageLibrary(options, (response: ImagePickerResponse) => {
+      if (response.assets && response.assets.length > 0) {
+        const addedPhotos: Photo[] = [];
+        response.assets.forEach((asset, index) => {
+          if (asset.uri) {
+            const tempId =
+              taskPhotos.length === 0
+                ? index
+                : Math.max(...taskPhotos.map((photo) => photo.id)) + 1 + index;
+            const file = {
+              id: tempId,
+              url:
+                Platform.OS === 'android'
+                  ? asset.uri
+                  : asset.uri.replace('file://', ''),
+              name: asset.fileName,
+              type: asset.type,
+            };
+            addedPhotos.push(file);
+          }
+        });
+        setTaskPhotos((prev) => [...prev, ...addedPhotos]);
+      }
+    });
+  };
+
+  const handleRemoveImage = (photoId: number) => {
+    Alert.alert('사진 삭제', '이 사진을 삭제하시겠습니까?', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '삭제',
+        onPress: () =>
+          setTaskPhotos((prev) => prev.filter((photo) => photo.id !== photoId)),
+      },
+    ]);
+  };
+
+  const prepareTaskData = () => {
+    const formData = new FormData();
+    const taskData: TaskUpdate = {};
+
+    if (initialTaskState?.title !== taskTitle) taskData.title = taskTitle;
+    if (initialTaskState?.content !== taskContent) {
+      taskData.content = taskContent;
+    }
+
+    if (
+      JSON.stringify(initialTaskState?.photos) !== JSON.stringify(taskPhotos)
+    ) {
+      const deletedPhotoIds = initialTaskState?.photos
+        .filter((photo) => !taskPhotos.some((p) => p.url === photo.url))
+        .map((photo) => photo.id);
+
+      const photosToUpload = taskPhotos
+        .filter(
+          (photo) => !initialTaskState?.photos.some((p) => p.url === photo.url),
+        )
+        .map((photo) => ({
+          uri: photo.url,
+          name: photo.name,
+          type: photo.type,
+        }));
+
+      taskData.deletedPhotoIds = deletedPhotoIds;
+      photosToUpload.forEach((photo) => formData.append('files', photo));
+    }
+
+    formData.append('data', JSON.stringify(taskData));
+    return formData;
+  };
+
+  const handleSaveTask = async () => {
+    if (!initialTaskState) return;
+
+    const formData = prepareTaskData();
+
+    try {
+      await apiClient.put(`/api/done-list/${id}`, formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      fetchTasks();
+      setIsTaskModified(false);
+    } catch (error) {
+      Toast.show({
+        type: 'error',
+        text1: '변경 사항을 저장하는 데 실패했습니다.',
+        text2: String(error),
+      });
+    }
+  };
+
   useEffect(() => {
     fetchTaskDetail();
   }, [fetchTaskDetail]);
+
+  useEffect(() => {
+    if (
+      initialTaskState &&
+      (taskTitle !== initialTaskState.title ||
+        taskContent !== initialTaskState.content ||
+        JSON.stringify(taskPhotos) !== JSON.stringify(initialTaskState.photos))
+    ) {
+      setIsTaskModified(true);
+    } else {
+      setIsTaskModified(false);
+    }
+  }, [taskTitle, taskContent, taskPhotos, initialTaskState, setIsTaskModified]);
+
+  useImperativeHandle(ref, () => ({ saveTask: handleSaveTask }));
 
   return (
     <ContentContainer>
@@ -91,14 +257,18 @@ const TaskModalContent = ({ id }: { id: number }) => {
         {taskPhotos.length > 0 && (
           <ScrollView
             horizontal
+            showsHorizontalScrollIndicator={false}
             contentContainerStyle={{
               flexGrow: 1,
               justifyContent: 'center',
             }}
           >
             <PhotoView>
-              {taskPhotos.map((photo: { id: number; url: string }) => (
-                <TouchableOpacity key={photo.id}>
+              {taskPhotos.map((photo) => (
+                <TouchableOpacity
+                  key={photo.id}
+                  onPress={() => handleRemoveImage(photo.id)}
+                >
                   <TaskPhoto source={{ uri: photo.url }} />
                 </TouchableOpacity>
               ))}
@@ -110,19 +280,20 @@ const TaskModalContent = ({ id }: { id: number }) => {
           onChangeText={setTaskContent}
           placeholder="어떤 일을 하셨나요? (최대 500자)"
           maxLength={500}
-          multiline={true}
+          multiline
         />
       </SpacedView>
       <ButtonContainer>
         <StyledButton
           buttonTheme="secondary"
-          title={`사진 추가 (${taskPhotos.length}/3)`}
-          onPress={() => console.log('사진 추가')}
+          title={`사진 추가 (${taskPhotos.length}/${MAX_PHOTO_COUNT})`}
+          disabled={taskPhotos.length === MAX_PHOTO_COUNT}
+          onPress={handlePickImage}
         />
-        <StyledButton title="저장" onPress={() => console.log('저장')} />
+        <StyledButton title="저장" onPress={handleSaveTask} />
       </ButtonContainer>
     </ContentContainer>
   );
-};
+});
 
 export default TaskModalContent;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4001,6 +4001,7 @@ __metadata:
     react-native-dotenv: ^3.4.11
     react-native-fast-shadow: ^0.1.1
     react-native-gesture-handler: ^2.20.0
+    react-native-image-picker: ^7.1.2
     react-native-linear-gradient: ^2.8.3
     react-native-modal-datetime-picker: ^18.0.0
     react-native-reanimated: ^3.15.5
@@ -9323,6 +9324,16 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: f573bc3717ae0209ff30bf62b95b3c7f11bd97f4797090211bce416c250388f55d1995aac0a7f1bbc99b06223ea64cbeae8d4ef88dcb8c877201b49163ea0e4b
+  languageName: node
+  linkType: hard
+
+"react-native-image-picker@npm:^7.1.2":
+  version: 7.1.2
+  resolution: "react-native-image-picker@npm:7.1.2"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: af52328b7cb06c28549442f0d923cfa92dde8d5a968a642336df4c882f81adbf0e5e606a14de27f96883a76fa1e03230061c4080011c9107942edebc8e09c478
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## 📌 관련 이슈
- closes #57 

## 🔑 주요 변경 사항
- `DoneListItem` 컴포넌트 클릭 시, 해당 던 리스트의 세부 내용을 확인하고, 수정할 수 있도록 모달 구현
  - 제목과 상세 내용을 수정할 수 있으며, 최대 3장의 사진을 업로드할 수 있음

  - 변경 사항을 추적하여 변경 사항을 저장하지 않은 상태에서 모달을 닫으려고 할 때, 변경 사항을 저장할 것인지 알림 표시

- iOS 환경에서, `ModalLayout`이 키보드에 가려지지 않도록 수정
- `DoneListItem` 컴포넌트를 스와이프 하여, 해당 항목을 삭제할 수 있도록 함

## 📸 스크린 샷 (선택 사항)
- `KeyboardAvoidingView`가 적용된 모달
<img src="https://github.com/user-attachments/assets/a5556215-127a-4985-a719-2ae033e172a6" width="400px" >

- 던 리스트 세부 항목 수정
<img src="https://github.com/user-attachments/assets/5ebe51b9-9bab-4466-95d4-0679fdb14f71" width="400px" >

- 변경 사항 추적
<img src="https://github.com/user-attachments/assets/c44f69bc-dafc-41af-bdb3-5521fd150f7b" width="400px" >

- 던 리스트 항목 삭제
<img src="https://github.com/user-attachments/assets/64321338-70d5-44aa-9e17-dafdb6c6b4dc" width="400px" >

## 📖 참고 사항
