### PR TITLE
Fix/#58: 로그인 후 서버에서 유저 정보를 받아오도록 수정

### DIFF
--- a/src/hooks/useFetchUserData.ts
+++ b/src/hooks/useFetchUserData.ts
@@ -1,0 +1,32 @@
+import { useCallback } from 'react';
+import { useSetRecoilState } from 'recoil';
+import Toast from 'react-native-toast-message';
+import apiClient from '@apis/client';
+import { userDataAtom } from '@recoil/atoms';
+
+const useFetchUserData = () => {
+  const setUserData = useSetRecoilState(userDataAtom);
+
+  const fetchUserData = useCallback(async () => {
+    try {
+      const response = await apiClient.get('/api/user');
+      const userDataFromServer = {
+        nickname: response.data.nickname,
+        age: response.data.age,
+        gender: response.data.gender,
+        isSurvey: response.data.isSurvey,
+      };
+      setUserData(userDataFromServer);
+    } catch (error) {
+      Toast.show({
+        type: 'error',
+        text1: '유저 정보를 가져오는 데 실패했습니다.',
+        text2: String(error),
+      });
+    }
+  }, [setUserData]);
+
+  return { fetchUserData };
+};
+
+export default useFetchUserData;

--- a/src/screens/SocialLogin/index.tsx
+++ b/src/screens/SocialLogin/index.tsx
@@ -14,6 +14,7 @@ import backgroundImage from '@assets/backgrounds/login.jpg';
 import appIcon from '@assets/icon-512.png';
 import useAnimatedValue from '@hooks/useAnimatedValue';
 import useNavigate from '@hooks/useNavigate';
+import useFetchUserData from '@hooks/useFetchUserData';
 
 const SloganContainer = styled(View)`
   position: absolute;
@@ -113,6 +114,7 @@ const LoginButton: React.FC<LoginButtonProps> = ({ onPress }) => (
 const SocialLogin = () => {
   const [showWebView, setShowWebView] = useState(false);
   const { navigateTo } = useNavigate();
+  const { fetchUserData } = useFetchUserData();
 
   const onTokenGenerated = async (token: string) => {
     try {
@@ -124,12 +126,21 @@ const SocialLogin = () => {
         text2: String(error),
       });
     }
+    await fetchUserData();
     navigateTo('Main');
   };
 
   if (showWebView) {
     return (
-      <ScreenLayout backgroundColor="white">
+      <ScreenLayout
+        backgroundColor="white"
+        contentStyle={{
+          paddingLeft: 0,
+          paddingRight: 0,
+          paddingTop: 0,
+          paddingBottom: 0,
+        }}
+      >
         <SocialLoginWebView onTokenGenerated={onTokenGenerated} />
       </ScreenLayout>
     );

--- a/src/screens/SplashScreen/index.tsx
+++ b/src/screens/SplashScreen/index.tsx
@@ -1,15 +1,13 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { View } from 'react-native';
 import styled from 'styled-components/native';
-import { useSetRecoilState } from 'recoil';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import Toast from 'react-native-toast-message';
 import { useNetInfo } from '@react-native-community/netinfo';
-import apiClient from '@apis/client';
-import { userDataAtom } from '@recoil/atoms';
 import ScreenLayout from '@screens/ScreenLayout';
 import AnimatedIcon from '@screens/SplashScreen/AnimatedIcon';
 import useNavigate from '@hooks/useNavigate';
+import useFetchUserData from '@hooks/useFetchUserData';
 
 const LogoContainer = styled(View)`
   flex: 1;
@@ -20,26 +18,7 @@ const LogoContainer = styled(View)`
 const SplashScreen = () => {
   const netInfo = useNetInfo();
   const { replaceTo } = useNavigate();
-  const setUserData = useSetRecoilState(userDataAtom);
-
-  const fetchUserData = useCallback(async () => {
-    try {
-      const response = await apiClient.get('/api/user');
-      const userDataFromServer = {
-        nickname: response.data.nickname,
-        age: response.data.age,
-        gender: response.data.gender,
-        isSurvey: response.data.isSurvey,
-      };
-      setUserData(userDataFromServer);
-    } catch (error) {
-      Toast.show({
-        type: 'error',
-        text1: '유저 정보를 가져오는 데 실패했습니다.',
-        text2: String(error),
-      });
-    }
-  }, [setUserData]);
+  const { fetchUserData } = useFetchUserData();
 
   useEffect(() => {
     const checkNetworkAndFetchData = async () => {


### PR DESCRIPTION
## 📌 관련 이슈
- closes #58 

## 🔑 주요 변경 사항
- `SplashScreen` 내 작성된 `fetchUserData` 함수를 `useFetchUserData` 커스텀 훅으로 분리하고 변경 사항 적용
- `SocialLogin` 스크린에서 로그인 성공 시, `useFetchUserData`를 사용하여 서버에서 유저 정보를 받아오도록 수정

## 📸 스크린 샷 (선택 사항)

## 📖 참고 사항
