### PR TITLE
Style/#64: 인라인 스타일링 제거 및 일부 컴포넌트 스타일 수정

### DIFF
--- a/src/components/ModalLayout/index.tsx
+++ b/src/components/ModalLayout/index.tsx
@@ -12,6 +12,10 @@ import StyledText from '@components/common/StyledText';
 import responsive from '@utils/responsive';
 import toastStyle from '@styles/toastStyle';
 
+const KeyboardAvoidingContainer = styled(KeyboardAvoidingView)`
+  flex: 1;
+`;
+
 const Overlay = styled(View)`
   background-color: rgba(0, 0, 0, 0.5);
   justify-content: center;
@@ -72,8 +76,7 @@ const ModalLayout: React.FC<ModalProps> = ({
       animationType="slide"
       onRequestClose={onClose}
     >
-      <KeyboardAvoidingView
-        style={{ flex: 1 }}
+      <KeyboardAvoidingContainer
         behavior={Platform.OS === 'ios' ? 'padding' : undefined}
       >
         <TouchableWithoutFeedback onPress={onClose}>
@@ -89,7 +92,7 @@ const ModalLayout: React.FC<ModalProps> = ({
             </TouchableWithoutFeedback>
           </Overlay>
         </TouchableWithoutFeedback>
-      </KeyboardAvoidingView>
+      </KeyboardAvoidingContainer>
       <Toast
         config={toastStyle}
         position="bottom"

--- a/src/components/common/MenuHeader/index.tsx
+++ b/src/components/common/MenuHeader/index.tsx
@@ -1,21 +1,31 @@
 import React from 'react';
+import { View } from 'react-native';
 import styled from 'styled-components/native';
 import StyledText from '@components/common/StyledText';
 import responsive from '@utils/responsive';
+
+const MenuWrapper = styled(View)<{ isTopLevel?: boolean }>`
+  margin-bottom: ${responsive(25, 'height')}px;
+  margin-top: ${(props) => (props.isTopLevel ? 0 : responsive(25, 'height'))}px;
+`;
 
 const MenuTitle = styled(StyledText)`
   font-family: ${(props) => props.theme.FONT_WEIGHTS.BOLD};
   font-size: ${responsive(16, 'height')}px;
   align-self: flex-start;
-  margin: ${responsive(25, 'height')}px 0;
 `;
 
 interface MenuHeaderProps {
   title: string;
+  isTopLevel?: boolean;
 }
 
-const MenuHeader: React.FC<MenuHeaderProps> = ({ title }) => {
-  return <MenuTitle>{title}</MenuTitle>;
+const MenuHeader: React.FC<MenuHeaderProps> = ({ title, isTopLevel }) => {
+  return (
+    <MenuWrapper isTopLevel={isTopLevel}>
+      <MenuTitle>{title}</MenuTitle>
+    </MenuWrapper>
+  );
 };
 
 export default MenuHeader;

--- a/src/screens/Diary/components/DoneListItem/index.tsx
+++ b/src/screens/Diary/components/DoneListItem/index.tsx
@@ -134,7 +134,9 @@ const DoneListItem: React.FC<DoneListItemProps> = ({
       />
       <DoneListContainer>
         <ButtonWrapper onPress={handleOpenModal}>
-          <DoneListTitle numberOfLines={1}>{title}</DoneListTitle>
+          <DoneListTitle numberOfLines={1}>
+            {title || '새로운 항목'}
+          </DoneListTitle>
         </ButtonWrapper>
       </DoneListContainer>
     </SwipeRow>

--- a/src/screens/Diary/components/DoneListItem/index.tsx
+++ b/src/screens/Diary/components/DoneListItem/index.tsx
@@ -39,6 +39,11 @@ const DeleteTaskButton = styled(TouchableOpacity)`
   justify-content: center;
 `;
 
+const StyledDeleteIcon = styled(DeleteIcon)`
+  position: absolute;
+  left: ${responsive(20, 'height')}px;
+`;
+
 const HiddenItemContainer = styled(DoneListContainer)`
   padding: 0;
 `;
@@ -72,8 +77,7 @@ const HiddenItems: React.FC<HiddenItemsProps> = ({
     <HiddenItemContainer>
       <Animated.View style={{ width: buttonWidth }}>
         <DeleteTaskButton onPress={() => onDeleteTask(taskId)}>
-          <DeleteIcon
-            style={{ position: 'absolute', left: responsive(20, 'height') }}
+          <StyledDeleteIcon
             width={responsive(15, 'height')}
             height={responsive(15, 'height')}
           />

--- a/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
+++ b/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
@@ -36,6 +36,13 @@ const TaskTitle = styled(TextInput)`
   margin-top: ${responsive(5, 'height')}px;
 `;
 
+const StyledScrollView = styled(ScrollView).attrs(() => ({
+  contentContainerStyle: {
+    flexGrow: 1,
+    justifyContent: 'center',
+  },
+}))``;
+
 const PhotoView = styled(View)`
   flex-direction: row;
   padding: 0 ${responsive(10)}px;
@@ -199,6 +206,7 @@ const TaskModalContent = forwardRef<
         }));
 
       taskData.deletedPhotoIds = deletedPhotoIds;
+      // @ts-expect-error
       photosToUpload.forEach((photo) => formData.append('files', photo));
     }
 
@@ -255,14 +263,7 @@ const TaskModalContent = forwardRef<
           maxLength={50}
         />
         {taskPhotos.length > 0 && (
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={{
-              flexGrow: 1,
-              justifyContent: 'center',
-            }}
-          >
+          <StyledScrollView horizontal showsHorizontalScrollIndicator={false}>
             <PhotoView>
               {taskPhotos.map((photo) => (
                 <TouchableOpacity
@@ -273,12 +274,12 @@ const TaskModalContent = forwardRef<
                 </TouchableOpacity>
               ))}
             </PhotoView>
-          </ScrollView>
+          </StyledScrollView>
         )}
         <TaskContent
           value={taskContent}
           onChangeText={setTaskContent}
-          placeholder="어떤 일을 하셨나요? (최대 500자)"
+          placeholder="어떤 일을 했었나요? (최대 500자)"
           maxLength={500}
           multiline
         />

--- a/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
+++ b/src/screens/Diary/components/TaskModal/TaskModalContent/index.tsx
@@ -31,9 +31,9 @@ const ContentContainer = styled(View)`
 `;
 
 const TaskTitle = styled(TextInput)`
+  font-family: 'GowunDodum-Regular';
   font-size: ${responsive(14, 'height')}px;
   padding: 0 ${responsive(15)}px;
-  margin-top: ${responsive(5, 'height')}px;
 `;
 
 const StyledScrollView = styled(ScrollView).attrs(() => ({
@@ -57,7 +57,7 @@ const TaskPhoto = styled(Image)`
 
 const TaskContent = styled(TextInput)`
   height: ${responsive(120, 'height')}px;
-  font-family: ${(props) => props.theme.FONT_WEIGHTS.LIGHT};
+  font-family: 'GowunDodum-Regular';
   font-size: ${responsive(14, 'height')}px;
   text-align: justify;
   text-align-vertical: top;

--- a/src/screens/Diary/index.tsx
+++ b/src/screens/Diary/index.tsx
@@ -128,7 +128,7 @@ const Diary = () => {
     const formData = new FormData();
     const newTask = {
       doneDate: localDate,
-      title: '새로운 작업',
+      title: '',
       content: '',
     };
     formData.append('data', JSON.stringify(newTask));

--- a/src/screens/Home/components/ActiveQuestItem/index.tsx
+++ b/src/screens/Home/components/ActiveQuestItem/index.tsx
@@ -23,7 +23,7 @@ const QuestContainer = styled(ItemLayout)`
 
 const QuestTitle = styled(StyledText)`
   font-size: ${responsive(14, 'height')}px;
-  letter-spacing: ${responsive(-0.5)}px;
+  letter-spacing: ${responsive(-0.5, 'height')}px;
 `;
 
 const IconWrapper = styled(View)`
@@ -41,11 +41,21 @@ const DeleteButton = styled(TouchableOpacity)`
   justify-content: center;
 `;
 
+const StyledDeleteIcon = styled(DeleteIcon)`
+  position: absolute;
+  left: ${responsive(25, 'height')}px;
+`;
+
 const CompleteButton = styled(TouchableOpacity)`
   height: 100%;
   background-color: ${(props) => props.theme.COLORS.BUTTON_GREEN};
   align-items: center;
   justify-content: center;
+`;
+
+const StyledCompleteIcon = styled(CompleteIcon)`
+  position: absolute;
+  left: ${responsive(25, 'height')}px;
 `;
 
 const DisabledOverlay = styled(View)`
@@ -128,8 +138,7 @@ const HiddenItems: React.FC<HiddenItemsProps> = ({
     <QuestContainer>
       <Animated.View style={{ width: buttonWidth }}>
         <DeleteButton onPress={() => onDeleteQuest(questId)}>
-          <DeleteIcon
-            style={{ position: 'absolute', left: responsive(25, 'height') }}
+          <StyledDeleteIcon
             width={responsive(20, 'height')}
             height={responsive(20, 'height')}
           />
@@ -137,8 +146,7 @@ const HiddenItems: React.FC<HiddenItemsProps> = ({
       </Animated.View>
       <Animated.View style={{ width: buttonWidth }}>
         <CompleteButton onPress={() => onCompleteQuest(questId)}>
-          <CompleteIcon
-            style={{ position: 'absolute', left: responsive(25, 'height') }}
+          <StyledCompleteIcon
             width={responsive(20, 'height')}
             height={responsive(20, 'height')}
           />

--- a/src/screens/Home/components/DailyProgress/BloomProgress/index.tsx
+++ b/src/screens/Home/components/DailyProgress/BloomProgress/index.tsx
@@ -104,7 +104,10 @@ const BloomProgress: React.FC<BloomProgressProps> = ({ exp }) => {
           />
         </FlowerIconWrapper>
         <ProgressBar>
-          <Animated.View style={{ right: progressRight, flex: 1 }}>
+          <Animated.View
+            // eslint-disable-next-line react-native/no-inline-styles
+            style={{ right: progressRight, flex: 1 }}
+          >
             <CurrentProgress
               colors={[
                 theme.COLORS.PROGRESS_BAR_SECONDARY,

--- a/src/screens/Home/components/DailyProgress/QuestProgress/index.tsx
+++ b/src/screens/Home/components/DailyProgress/QuestProgress/index.tsx
@@ -6,13 +6,6 @@ import StyledText from '@components/common/StyledText';
 import responsive from '@utils/responsive';
 import theme from '@styles/theme';
 
-const QuestProgressContainer = styled(View)`
-  width: ${responsive(160)}px;
-  aspect-ratio: 1;
-`;
-
-const QuestProgressIndicator = styled(AnimatedCircularProgress)``;
-
 const TextContainer = styled(View)`
   align-items: center;
 `;
@@ -47,25 +40,23 @@ const QuestProgress: React.FC<QuestProgressProps> = ({
   }, [completedQuests, totalQuests]);
 
   return (
-    <QuestProgressContainer>
-      <QuestProgressIndicator
-        size={responsive(160)}
-        width={responsive(10)}
-        fill={progressPercentage}
-        tintColor={theme.COLORS.PROGRESS_BAR_PRIMARY}
-        backgroundColor={theme.COLORS.PROGRESS_BAR_BACKGROUND}
-        rotation={0}
-      >
-        {() => (
-          <TextContainer>
-            <Title>퀘스트 진행률</Title>
-            <ProgressText weight="MEDIUM">
-              {completedQuests} / {totalQuests}
-            </ProgressText>
-          </TextContainer>
-        )}
-      </QuestProgressIndicator>
-    </QuestProgressContainer>
+    <AnimatedCircularProgress
+      size={responsive(160)}
+      width={responsive(10)}
+      fill={progressPercentage}
+      tintColor={theme.COLORS.PROGRESS_BAR_PRIMARY}
+      backgroundColor={theme.COLORS.PROGRESS_BAR_BACKGROUND}
+      rotation={0}
+    >
+      {() => (
+        <TextContainer>
+          <Title>퀘스트 진행률</Title>
+          <ProgressText weight="MEDIUM">
+            {completedQuests} / {totalQuests}
+          </ProgressText>
+        </TextContainer>
+      )}
+    </AnimatedCircularProgress>
   );
 };
 

--- a/src/screens/SocialLogin/SocialLoginWebView.tsx
+++ b/src/screens/SocialLogin/SocialLoginWebView.tsx
@@ -27,6 +27,11 @@ const CenteredView = styled(View)`
   justify-content: center;
 `;
 
+const StyledWebView = styled(WebView)`
+  flex: 1;
+  width: 100%;
+`;
+
 const LoadingIndicator = () => (
   <CenteredView>
     <ActivityIndicator size="large" color="#999999" />
@@ -57,8 +62,7 @@ const SocialLoginWebView: React.FC<SocialLoginWebViewProps> = ({
     <LoadingIndicator />
   ) : (
     <CenteredView>
-      <WebView
-        style={{ flex: 1, width: '100%' }}
+      <StyledWebView
         incognito={true}
         source={{ uri: fetchedUri }}
         onShouldStartLoadWithRequest={handleNavigation}

--- a/src/screens/SocialLogin/index.tsx
+++ b/src/screens/SocialLogin/index.tsx
@@ -47,6 +47,21 @@ const HighlightedText = styled(StyledText)`
   letter-spacing: 0;
 `;
 
+const NoPaddingLayout = styled(ScreenLayout).attrs(() => ({
+  contentStyle: {
+    paddingLeft: 0,
+    paddingRight: 0,
+    paddingTop: 0,
+    paddingBottom: 0,
+  },
+}))``;
+
+const StyledImageBackground = styled(ImageBackground)`
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+`;
+
 const Slogan = () => {
   const { animatedValue: iconY, animateToValue: afterIconY } =
     useAnimatedValue(50);
@@ -132,28 +147,17 @@ const SocialLogin = () => {
 
   if (showWebView) {
     return (
-      <ScreenLayout
-        backgroundColor="white"
-        contentStyle={{
-          paddingLeft: 0,
-          paddingRight: 0,
-          paddingTop: 0,
-          paddingBottom: 0,
-        }}
-      >
+      <NoPaddingLayout backgroundColor="white">
         <SocialLoginWebView onTokenGenerated={onTokenGenerated} />
-      </ScreenLayout>
+      </NoPaddingLayout>
     );
   }
 
   return (
-    <ImageBackground
-      source={backgroundImage}
-      style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}
-    >
+    <StyledImageBackground source={backgroundImage}>
       <Slogan />
       <LoginButton onPress={() => setShowWebView(true)} />
-    </ImageBackground>
+    </StyledImageBackground>
   );
 };
 

--- a/src/screens/SplashScreen/AnimatedIcon/index.tsx
+++ b/src/screens/SplashScreen/AnimatedIcon/index.tsx
@@ -6,8 +6,8 @@ import responsive from '@utils/responsive';
 import innerHtml from '@screens/SplashScreen/AnimatedIcon/innerHtml';
 
 const WebViewContainer = styled(View)`
-  width: ${responsive(110)}px;
-  height: ${responsive(155)}px;
+  width: ${responsive(110, 'height')}px;
+  height: ${responsive(155, 'height')}px;
 `;
 
 const StyledWebView = styled(WebView)`

--- a/src/screens/SplashScreen/AnimatedIcon/innerHtml/index.ts
+++ b/src/screens/SplashScreen/AnimatedIcon/innerHtml/index.ts
@@ -28,7 +28,7 @@ const innerHtml = `
         position: relative;
         width: 64%;
         left: 18%;
-        top: ${responsive(19)}px;
+        top: ${responsive(19, 'height')}px;
         z-index: 2;
       }
       
@@ -36,7 +36,7 @@ const innerHtml = `
         position: relative;
         width: 84%;
         left: 8%;
-        top: ${responsive(45)}px;
+        top: ${responsive(45, 'height')}px;
         opacity: 0;
         transition: opacity 0.5s ease-in-out;
       }

--- a/src/screens/SplashScreen/index.tsx
+++ b/src/screens/SplashScreen/index.tsx
@@ -45,7 +45,7 @@ const SplashScreen = () => {
   }, [netInfo.isInternetReachable, replaceTo, fetchUserData]);
 
   return (
-    <ScreenLayout backgroundColor="white" contentStyle={{ padding: 0 }}>
+    <ScreenLayout backgroundColor="white">
       <LogoContainer>
         <AnimatedIcon />
       </LogoContainer>


### PR DESCRIPTION
## 📌 관련 이슈
- closes #64 

## 🔑 주요 변경 사항
- 컴포넌트 내에서 사용되던 인라인 스타일을 별도의 스타일 컴포넌트로 분리
- 스플래시 화면에서 아이콘 크기 조정
- 메뉴 헤더가 최상위 항목일 때 `margin-top`을 0으로 설정
- 던 리스트 항목을 생성할 때 디폴트 제목 제거
- ~~던 리스트 항목 모달의 `font-family` 변경~~
