### PR TITLE
Feature/#66: 리프레시 토큰 관리 및 토큰 검증 구현

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -1,5 +1,4 @@
 import axios from 'axios';
-import AsyncStorage from '@react-native-async-storage/async-storage';
 import { API_BASE_URL } from '@env';
 
 const apiClient = axios.create({
@@ -8,19 +7,5 @@ const apiClient = axios.create({
     'Content-Type': 'application/json',
   },
 });
-
-apiClient.interceptors.request.use(
-  async (config) => {
-    const token = await AsyncStorage.getItem('authToken');
-    const modifiedConfig = { ...config };
-    if (token) {
-      modifiedConfig.headers.Authorization = token;
-    }
-    return modifiedConfig;
-  },
-  (error) => {
-    return Promise.reject(error);
-  },
-);
 
 export default apiClient;

--- a/src/hooks/useAxiosInterceptor.ts
+++ b/src/hooks/useAxiosInterceptor.ts
@@ -1,0 +1,112 @@
+import { useEffect, useCallback } from 'react';
+import {
+  AxiosInstance,
+  AxiosError,
+  AxiosResponse,
+  InternalAxiosRequestConfig,
+} from 'axios';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import useNavigate from '@hooks/useNavigate';
+
+interface AuthorizationErrorResponse {
+  errorCode: string;
+  message: string;
+}
+
+interface AuthorizationError extends AxiosError {
+  response?: AxiosResponse<AuthorizationErrorResponse>;
+}
+
+const useAxiosInterceptor = (instance: AxiosInstance) => {
+  const { navigateTo } = useNavigate();
+
+  const handleRequest = useCallback(
+    async (config: InternalAxiosRequestConfig) => {
+      const accessToken = await AsyncStorage.getItem('accessToken');
+      const newConfig = { ...config };
+
+      if (accessToken && newConfig.headers) {
+        newConfig.headers.Authorization = `${accessToken}`;
+      }
+
+      return newConfig;
+    },
+    [],
+  );
+
+  const handleResponse = useCallback((response: AxiosResponse) => {
+    return response;
+  }, []);
+
+  const handleError = useCallback(
+    async (error: AuthorizationError) => {
+      const { response } = error;
+
+      if (response && response.data) {
+        const { errorCode } = response.data;
+
+        if (errorCode === 'T2' || errorCode === 'T4') {
+          navigateTo('Login');
+          return Promise.reject(error);
+        }
+
+        if (errorCode === 'T1' || errorCode === 'T3') {
+          const refreshToken = await AsyncStorage.getItem('refreshToken');
+          if (refreshToken) {
+            try {
+              const refreshResponse = await instance.post('/api/auth/refresh', {
+                refreshToken,
+              });
+              const newAccessToken = refreshResponse.data.accessToken;
+              await AsyncStorage.setItem('accessToken', newAccessToken);
+
+              if (error.config) {
+                const newConfig = { ...error.config };
+                newConfig.headers = newConfig.headers || {};
+                newConfig.headers.Authorization = newAccessToken;
+                return instance(newConfig);
+              }
+            } catch (refreshError) {
+              navigateTo('Login');
+              return Promise.reject(refreshError);
+            }
+          }
+        }
+      }
+
+      return Promise.reject(error);
+    },
+    [navigateTo, instance],
+  );
+
+  const setupInterceptors = useCallback(() => {
+    const requestInterceptor = instance.interceptors.request.use(
+      handleRequest,
+      handleError,
+    );
+    const responseInterceptor = instance.interceptors.response.use(
+      handleResponse,
+      handleError,
+    );
+
+    return { requestInterceptor, responseInterceptor };
+  }, [instance, handleRequest, handleResponse, handleError]);
+
+  const ejectInterceptors = useCallback(
+    (requestInterceptor: number, responseInterceptor: number) => {
+      instance.interceptors.request.eject(requestInterceptor);
+      instance.interceptors.response.eject(responseInterceptor);
+    },
+    [instance],
+  );
+
+  useEffect(() => {
+    const { requestInterceptor, responseInterceptor } = setupInterceptors();
+
+    return () => {
+      ejectInterceptors(requestInterceptor, responseInterceptor);
+    };
+  }, [instance, setupInterceptors, ejectInterceptors]);
+};
+
+export default useAxiosInterceptor;

--- a/src/hooks/useFetchUserData.ts
+++ b/src/hooks/useFetchUserData.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 import { useSetRecoilState } from 'recoil';
-import Toast from 'react-native-toast-message';
 import apiClient from '@apis/client';
 import { userDataAtom } from '@recoil/atoms';
 
@@ -18,11 +17,7 @@ const useFetchUserData = () => {
       };
       setUserData(userDataFromServer);
     } catch (error) {
-      Toast.show({
-        type: 'error',
-        text1: '유저 정보를 가져오는 데 실패했습니다.',
-        text2: String(error),
-      });
+      throw new Error();
     }
   }, [setUserData]);
 

--- a/src/hooks/useSocialLogin.ts
+++ b/src/hooks/useSocialLogin.ts
@@ -4,9 +4,12 @@ import apiClient from '@apis/client';
 
 interface SocialLoginResponse {
   accessToken: string;
+  refreshToken: string;
 }
 
-const useSocialLogin = (onTokenGenerated: (token: string) => void) => {
+const useSocialLogin = (
+  onTokenGenerated: (accessToken: string, refreshToken: string) => void,
+) => {
   const [fetchedUri, setFetchedUri] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
 
@@ -36,7 +39,7 @@ const useSocialLogin = (onTokenGenerated: (token: string) => void) => {
         '/api/auth/kakao',
         { authorizationCode: code },
       );
-      onTokenGenerated(response.data.accessToken);
+      onTokenGenerated(response.data.accessToken, response.data.refreshToken);
     } catch (error) {
       Toast.show({
         type: 'error',

--- a/src/screens/SocialLogin/SocialLoginWebView.tsx
+++ b/src/screens/SocialLogin/SocialLoginWebView.tsx
@@ -19,7 +19,7 @@ const getQueryParams = (url: string): Record<string, string> => {
 };
 
 interface SocialLoginWebViewProps {
-  onTokenGenerated: (token: string) => void;
+  onTokenGenerated: (accessToken: string, refreshToken: string) => void;
 }
 
 const CenteredView = styled(View)`

--- a/src/screens/SocialLogin/index.tsx
+++ b/src/screens/SocialLogin/index.tsx
@@ -131,9 +131,15 @@ const SocialLogin = () => {
   const { navigateTo } = useNavigate();
   const { fetchUserData } = useFetchUserData();
 
-  const onTokenGenerated = async (token: string) => {
+  const onTokenGenerated = async (
+    accessToken: string,
+    refreshToken: string,
+  ) => {
     try {
-      await AsyncStorage.setItem('authToken', token);
+      await AsyncStorage.multiSet([
+        ['accessToken', accessToken],
+        ['refreshToken', refreshToken],
+      ]);
     } catch (error) {
       Toast.show({
         type: 'error',

--- a/src/screens/SplashScreen/index.tsx
+++ b/src/screens/SplashScreen/index.tsx
@@ -30,10 +30,14 @@ const SplashScreen = () => {
         return;
       }
 
-      const token = await AsyncStorage.getItem('authToken');
-      if (token) {
-        await fetchUserData();
-        replaceTo('Main');
+      const accessToken = await AsyncStorage.getItem('accessToken');
+      if (accessToken) {
+        try {
+          await fetchUserData();
+          replaceTo('Main');
+        } catch (error) {
+          replaceTo('Login');
+        }
       } else {
         replaceTo('Login');
       }

--- a/src/screens/navigators/StackNavigator/index.tsx
+++ b/src/screens/navigators/StackNavigator/index.tsx
@@ -5,10 +5,14 @@ import SplashScreen from '@screens/SplashScreen';
 import SocialLogin from '@screens/SocialLogin';
 import BottomTabNavigator from '@screens/navigators/BottomTabNavigator';
 import UserSettings from '@screens/UserSettings';
+import useAxiosInterceptor from '@hooks/useAxiosInterceptor';
+import apiClient from '@apis/client';
 
 const Stack = createStackNavigator<StackParamList>();
 
 const StackNavigator = () => {
+  useAxiosInterceptor(apiClient);
+
   return (
     <Stack.Navigator
       initialRouteName="Splash"


### PR DESCRIPTION
## 📌 관련 이슈
- closes #66 

## 🔑 주요 변경 사항
- 리프레시 토큰 관리: 사용자가 인증을 받은 후 발급된 리프레시 토큰을 `AsyncStorage`에 저장

- 토큰 갱신 및 검증
  - 액세스 토큰이 만료되었거나, 유효하지 않은 경우 저장되어 있는 리프레시 토큰을 사용하여 액세스 토큰 재발급 시도
  - 액세스 토큰 재발급이 성공한 경우, 갱신된 액세스 토큰으로 해당 요청을 다시 보내고, 재발급 실패 시 로그인 화면으로 이동
  - 리프레시 토큰이 만료되었거나, 유효하지 않은 경우 로그인 화면으로 이동

- Axios 인터셉터 로직 분리: `apiClient.ts`에 작성되어 있던 인터셉터 로직을 `useAxiosInterceptor` 훅으로 분리하여, 인터셉터 내에서 `useNavigate` 훅을 사용할 수 있도록 함
