### PR TITLE
Feature/#69: 로그아웃 기능 구현

### DIFF
--- a/src/hooks/useAxiosInterceptor.ts
+++ b/src/hooks/useAxiosInterceptor.ts
@@ -26,7 +26,7 @@ const useAxiosInterceptor = (instance: AxiosInstance) => {
       const newConfig = { ...config };
 
       if (accessToken && newConfig.headers) {
-        newConfig.headers.Authorization = `${accessToken}`;
+        newConfig.headers.Authorization = accessToken;
       }
 
       return newConfig;

--- a/src/screens/UserSettings/components/SettingsItem/index.tsx
+++ b/src/screens/UserSettings/components/SettingsItem/index.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+import { TouchableOpacity } from 'react-native';
+import styled from 'styled-components/native';
+import StyledText from '@components/common/StyledText';
+import responsive from '@utils/responsive';
+
+const MenuButton = styled(TouchableOpacity)<{ isLast?: boolean }>`
+  padding: ${responsive(25, 'height')}px ${responsive(5, 'height')}px;
+  border-bottom-width: ${(props) => (props.isLast ? 0 : 0.5)}px;
+  border-bottom-color: lightgray;
+`;
+
+interface SettingsItemProps {
+  title: string;
+  onPress: () => void;
+  isLast?: boolean;
+}
+
+const SettingsItem: React.FC<SettingsItemProps> = ({
+  title,
+  onPress,
+  isLast,
+}) => {
+  return (
+    <MenuButton onPress={onPress} isLast={isLast}>
+      <StyledText>{title}</StyledText>
+    </MenuButton>
+  );
+};
+
+export default SettingsItem;

--- a/src/screens/UserSettings/index.tsx
+++ b/src/screens/UserSettings/index.tsx
@@ -4,21 +4,29 @@ import ScreenLayout from '@screens/ScreenLayout';
 import UserSettingsHeader from '@screens/UserSettings/components/UserSettingsHeader';
 import SettingsItem from '@screens/UserSettings/components/SettingsItem';
 import useNavigate from '@hooks/useNavigate';
-import { ScrollView } from 'react-native';
+import { Alert, ScrollView } from 'react-native';
 
 const UserSettings = () => {
   const { navigateTo } = useNavigate();
 
-  const logout = async () => {
-    await AsyncStorage.multiRemove(['accessToken', 'refreshToken']);
-    navigateTo('Login');
+  const handleLogout = () => {
+    Alert.alert('bloom', '이 기기에서 로그아웃하시겠습니까?', [
+      { text: '취소', style: 'cancel' },
+      {
+        text: '로그아웃',
+        onPress: async () => {
+          await AsyncStorage.multiRemove(['accessToken', 'refreshToken']);
+          navigateTo('Login');
+        },
+      },
+    ]);
   };
 
   return (
     <ScreenLayout>
       <UserSettingsHeader title="설정" />
       <ScrollView showsVerticalScrollIndicator={false}>
-        <SettingsItem title="로그아웃" onPress={logout} isLast={true} />
+        <SettingsItem title="로그아웃" onPress={handleLogout} isLast={true} />
       </ScrollView>
     </ScreenLayout>
   );

--- a/src/screens/UserSettings/index.tsx
+++ b/src/screens/UserSettings/index.tsx
@@ -1,11 +1,25 @@
 import React from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import ScreenLayout from '@screens/ScreenLayout';
 import UserSettingsHeader from '@screens/UserSettings/components/UserSettingsHeader';
+import SettingsItem from '@screens/UserSettings/components/SettingsItem';
+import useNavigate from '@hooks/useNavigate';
+import { ScrollView } from 'react-native';
 
 const UserSettings = () => {
+  const { navigateTo } = useNavigate();
+
+  const logout = async () => {
+    await AsyncStorage.multiRemove(['accessToken', 'refreshToken']);
+    navigateTo('Login');
+  };
+
   return (
     <ScreenLayout>
       <UserSettingsHeader title="설정" />
+      <ScrollView showsVerticalScrollIndicator={false}>
+        <SettingsItem title="로그아웃" onPress={logout} isLast={true} />
+      </ScrollView>
     </ScreenLayout>
   );
 };


### PR DESCRIPTION
## 📌 관련 이슈
- closes #69 

## 🔑 주요 변경 사항
-  `SettingsItem` 컴포넌트 작성
    - `isLast` prop을 사용하여 마지막 항목에서의 `border`를 제거할 수 있도록 함

- 로그아웃 기능 구현
  -  사용자가 로그아웃 요청 시, `AsyncStorage`에서 액세스 토큰과 리프레시 토큰을 삭제하고 로그인 화면으로 리디렉션

- `UserSettings` 스크린에 로그아웃 버튼 추가

## 📸 스크린 샷 (선택 사항)
<img src="https://github.com/user-attachments/assets/d341bc22-e048-4c9b-93df-f574f3ee561e" width="400px" >
